### PR TITLE
Add missing `js_of_ocaml-ppx` to `js_of_ocaml-eio.opam`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
  (synopsis "Simple Eio scheduler for JavaScript environments")
  (description "An Eio scheduler suitable for JavaScript environments.")
  (depends
+  (mdx (and (>= 2.4.1) :with-test))
   (eio (>= 0.14))))
 (package
  (name eio_brr)
@@ -25,5 +26,6 @@
  (description "An Eio counterpart to package js_of_ocaml-lwt.")
  (depends
   (eio_js_backend (= :version))
+  (js_of_ocaml-ppx (>= "5.0.1"))
   (js_of_ocaml (>= 5.0.1))))
 (using mdx 0.2)

--- a/eio_js_backend.opam
+++ b/eio_js_backend.opam
@@ -10,6 +10,7 @@ doc: "https://ocaml-multicore.github.io/eio_js/"
 bug-reports: "https://github.com/ocaml-multicore/eio_js/issues"
 depends: [
   "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
   "eio" {>= "0.14"}
   "odoc" {with-doc}
 ]

--- a/js_of_ocaml-eio.opam
+++ b/js_of_ocaml-eio.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/ocaml-multicore/eio_js/issues"
 depends: [
   "dune" {>= "3.9"}
   "eio_js_backend" {= version}
+  "js_of_ocaml-ppx" {>= "5.0.1"}
   "js_of_ocaml" {>= "5.0.1"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
```
    File "lib_js_of_ocaml_eio/dune", line 6, characters 18-33:
    6 |  (preprocess (pps js_of_ocaml-ppx)))
                          ^^^^^^^^^^^^^^^
    Error: Library "js_of_ocaml-ppx" not found.
```